### PR TITLE
Added option to avoid slider stopping on blur

### DIFF
--- a/ideal-image-slider.js
+++ b/ideal-image-slider.js
@@ -410,6 +410,7 @@ var IdealImageSlider = (function() {
 			keyboardNav: true,
 			previousNavSelector: '',
 			nextNavSelector: '',
+			stopOnBlur: true,
 			classes: {
 				container: 'ideal-image-slider',
 				slide: 'iis-slide',
@@ -647,9 +648,11 @@ var IdealImageSlider = (function() {
 		this.settings.onStart.apply(this);
 
 		// Stop if window blur
-		window.onblur = function() {
-			this.stop();
-		}.bind(this);
+		if (this.settings.stopOnBlur) {
+			window.onblur = function() {
+				this.stop();
+			}.bind(this);
+		}
 	};
 
 	Slider.prototype.stop = function() {


### PR DESCRIPTION
Added the option stopOnBlur (default to true) to prevent the stop of the slider if the browser window lost focus.